### PR TITLE
BREAKING: Upgrade to draft-06

### DIFF
--- a/src/schema.json
+++ b/src/schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "JSON schema for Graphcool graphcool.yml files",
   "definitions": {
     "function": {


### PR DESCRIPTION
This upgrades the schema to draft-06. Do not merge before the Graphcool CLI either locks the dependency to the current `graphcool-json-schema` version, or is updated for this version.